### PR TITLE
Update paymentAmount type to number in emailTest action

### DIFF
--- a/src/app/actions/emailTest.ts
+++ b/src/app/actions/emailTest.ts
@@ -130,7 +130,7 @@ export async function testRegistrationConfirmation() {
     assemblyDates: '15/03/2024 - 17/03/2024',
     modalityName: 'Participante - Teste',
     paymentRequired: true,
-    paymentAmount: 'R$ 150,00',
+    paymentAmount: 150.00,
     registrationUrl: `${env.NEXTAUTH_URL}/test/payment`,
   };
 


### PR DESCRIPTION
- Changed paymentAmount from a formatted string to a numeric type for consistency with recent refactoring.
- This update aligns with previous changes to improve clarity and accuracy in payment handling across the application.