### PR TITLE
Implement session data enrichment for report generation

### DIFF
--- a/src/app/ag/admin/page.tsx
+++ b/src/app/ag/admin/page.tsx
@@ -490,7 +490,10 @@ export default function AGAdminPage() {
             });
 
             // Fetch session data directly using the convex client
-            const sessionData = await convex.query(convexApi.agSessions.getSessionWithStats, { sessionId: sessionId as any });
+            // Use enriched data for sessão type sessions to get CPF, email, and emailSolar
+            const sessionData = sessionType === "sessao" 
+                ? await convex.query(convexApi.agSessions.getSessionWithEnrichedData, { sessionId: sessionId as any })
+                : await convex.query(convexApi.agSessions.getSessionWithStats, { sessionId: sessionId as any });
             
             if (!sessionData?.attendanceRecords || sessionData.attendanceRecords.length === 0) {
                 console.log("No attendance records found in session data:", {

--- a/src/app/comites-locais/chamada-ag/page.tsx
+++ b/src/app/comites-locais/chamada-ag/page.tsx
@@ -289,7 +289,7 @@ export default function ChamadaAGPage() {
         selectedAssemblyId ? { assemblyId: selectedAssemblyId as any } : "skip"
     );
     const currentSessionData = useQuery(
-        convexApi.agSessions?.getSessionWithStats,
+        currentSessionType === "sessao" ? convexApi.agSessions?.getSessionWithEnrichedData : convexApi.agSessions?.getSessionWithStats,
         currentSessionId ? { sessionId: currentSessionId as any } : "skip"
     );
     const sessionAttendance = useQuery(

--- a/src/lib/reportGenerator.ts
+++ b/src/lib/reportGenerator.ts
@@ -231,6 +231,12 @@ export const generateAGReport = (
                         'Nome': record.participantName || 'N/A',
                         'Cargo/Função': record.participantRole || 'Participante',
                         'Comitê/Instituição': record.comiteLocal || '-',
+                        'Email': record.email || '-',
+                        'Email Solar': record.emailSolar || '-',
+                        'CPF': record.cpf || '-',
+                        'Celular': record.celular || '-',
+                        'Cidade': record.cidade || '-',
+                        'UF': record.uf || '-',
                         'ID': record.participantId || '-',
                         'Status': record.attendance === "present" ? "Presente" : 
                                  record.attendance === "absent" ? "Ausente" : 


### PR DESCRIPTION
- Added `getSessionWithEnrichedData` query to fetch session details with enriched registration data for "sessao" type sessions, including participant email, CPF, and other relevant fields.
- Updated `AGAdminPage` and `ChamadaAGPage` to utilize the new enriched data query when fetching session information.
- Enhanced report generation to include additional participant details such as email, CPF, and location data for improved reporting accuracy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Session reports for "sessao" type now include enriched participant information such as email, emailSolar, CPF, phone, city, state, school, local committee, and participant role.
- **Enhancements**
  - Session and attendance data retrieval is now tailored by session type, providing more detailed data for "sessao" sessions.
  - Downloaded reports for "sessao" sessions display additional participant details in the exported worksheet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->